### PR TITLE
Use production config from Heroku ENV variables and decrease socket tiimeout

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: mix phx.server

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -23,7 +23,7 @@ if config_env() == :prod do
   maybe_ipv6 = if System.get_env("ECTO_IPV6"), do: [:inet6], else: []
 
   config :surface_playground, SurfacePlayground.Repo,
-    # ssl: true,
+    ssl: true,
     url: database_url,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
     socket_options: maybe_ipv6
@@ -40,11 +40,12 @@ if config_env() == :prod do
       You can generate one by calling: mix phx.gen.secret
       """
 
-  host = System.get_env("PHX_HOST") || "example.com"
+  host = System.get_env("PHX_HOST") || "surfaceplayground.herokuapp.com"
   port = String.to_integer(System.get_env("PORT") || "4000")
 
   config :surface_playground, SurfacePlaygroundWeb.Endpoint,
-    url: [host: host, port: 443],
+    url: [scheme: "https", host: host, port: 443],
+    force_ssl: [rewrite_on: [:x_forwarded_proto]],
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,0 +1,10 @@
+# Elixir version
+elixir_version=1.12.2
+
+# Erlang version
+# https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
+erlang_version=24.0.3
+
+# Invoke assets.deploy defined in your mix.exs to deploy assets with esbuild
+# Note we nuke the esbuild executable from the image
+hook_post_compile="eval mix assets.deploy && rm -f _build/esbuild*"

--- a/lib/surface_playground_web/endpoint.ex
+++ b/lib/surface_playground_web/endpoint.ex
@@ -10,7 +10,7 @@ defmodule SurfacePlaygroundWeb.Endpoint do
     signing_salt: "S/HP8CGh"
   ]
 
-  socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
+  socket "/live", Phoenix.LiveView.Socket, websocket: [timeout: 45_000, connect_info: [session: @session_options]]
 
   # Serve at "/" the static files from "priv/static" directory.
   #


### PR DESCRIPTION
- https://hexdocs.pm/phoenix/heroku.html
- https://devcenter.heroku.com/articles/buildpacks#using-a-third-party-buildpack
- https://github.com/dwyl/learn-heroku/blob/master/elixir-phoenix-app-deployment.md


When set the configuration for `force_ssl`:

```elixir
force_ssl: [rewrite_on: [:x_forwarded_proto]],
```

After deploy:
```log
2021-12-17T23:04:57.917635+00:00 heroku[web.1]: Starting process with command `MIX_ENV=prod mix phx.server`
2021-12-17T23:05:03.675006+00:00 app[web.1]: 23:05:03.674 [error] :force_ssl mismatch for SurfacePlaygroundWeb.Endpoint.
2021-12-17T23:05:03.675014+00:00 app[web.1]: 
2021-12-17T23:05:03.675015+00:00 app[web.1]: Compile time configuration: nil
2021-12-17T23:05:03.675016+00:00 app[web.1]: Runtime configuration     : [rewrite_on: [:x_forwarded_proto]]
2021-12-17T23:05:03.675016+00:00 app[web.1]: 
2021-12-17T23:05:03.675016+00:00 app[web.1]: :force_ssl is a compile-time configuration, so setting
2021-12-17T23:05:03.675017+00:00 app[web.1]: it at runtime has no effect. Therefore you must set it in your
2021-12-17T23:05:03.675017+00:00 app[web.1]: config/prod.exs or similar (not in your config/releases.exs)
2021-12-17T23:05:03.675018+00:00 app[web.1]: and make sure the value doesn't change.
2021-12-17T23:05:03.675019+00:00 app[web.1]: 
2021-12-17T23:05:03.676229+00:00 app[web.1]: 23:05:03.675 [info] Application surface_playground exited: SurfacePlayground.Application.start(:normal, []) returned an error: shutdown: failed to start child: SurfacePlaygroundWeb.Endpoint
2021-12-17T23:05:03.676230+00:00 app[web.1]:     ** (EXIT) an exception was raised:
2021-12-17T23:05:03.676231+00:00 app[web.1]:         ** (ArgumentError) expected these options to be unchanged from compile time: [:force_ssl]
2021-12-17T23:05:03.676232+00:00 app[web.1]:             (phoenix 1.6.3) lib/phoenix/endpoint/supervisor.ex:55: Phoenix.Endpoint.Supervisor.check_compile_configs!/2
2021-12-17T23:05:03.676233+00:00 app[web.1]:             (phoenix 1.6.3) lib/phoenix/endpoint/supervisor.ex:92: Phoenix.Endpoint.Supervisor.init/1
2021-12-17T23:05:03.676233+00:00 app[web.1]:             (stdlib 3.16.1) supervisor.erl:330: :supervisor.init/1
2021-12-17T23:05:03.676233+00:00 app[web.1]:             (stdlib 3.16.1) gen_server.erl:423: :gen_server.init_it/2
2021-12-17T23:05:03.676234+00:00 app[web.1]:             (stdlib 3.16.1) gen_server.erl:390: :gen_server.init_it/6
2021-12-17T23:05:03.676234+00:00 app[web.1]:             (stdlib 3.16.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
2021-12-17T23:05:05.496843+00:00 heroku[web.1]: Process exited with status 1
2021-12-17T23:05:05.591365+00:00 heroku[web.1]: State changed from starting to crashed
2021-12-17T23:05:05.215433+00:00 app[web.1]: {"Kernel pid terminated",application_controller,"{application_start_failure,surface_playground,{{shutdown,{failed_to_start_child,'Elixir.SurfacePlaygroundWeb.Endpoint',{#{'__exception__' => true,'__struct__' => 'Elixir.ArgumentError',message => <<\"expected these options to be unchanged from compile time: [:force_ssl]\">>},[{'Elixir.Phoenix.Endpoint.Supervisor','check_compile_configs!',2,[{file,\"lib/phoenix/endpoint/supervisor.ex\"},{line,55}]},{'Elixir.Phoenix.Endpoint.Supervisor',init,1,[{file,\"lib/phoenix/endpoint/supervisor.ex\"},{line,92}]},{supervisor,init,1,[{file,\"supervisor.erl\"},{line,330}]},{gen_server,init_it,2,[{file,\"gen_server.erl\"},{line,423}]},{gen_server,init_it,6,[{file,\"gen_server.erl\"},{line,390}]},{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,226}]}]}}},{'Elixir.SurfacePlayground.Application',start,[normal,[]]}}}"}
2021-12-17T23:05:05.215959+00:00 app[web.1]: Kernel pid terminated (application_controller) ({application_start_failure,surface_playground,{{shutdown,{failed_to_start_child,'Elixir.SurfacePlaygroundWeb.Endpoint',{#{'__exception__' => true,'__str
2021-12-17T23:05:05.216173+00:00 app[web.1]: 
```